### PR TITLE
Changed input summary format to be SEE (Summary Evaluation Environment).

### DIFF
--- a/pyrouge/Rouge155.py
+++ b/pyrouge/Rouge155.py
@@ -449,7 +449,7 @@ class Rouge155(object):
     <EVAL ID="{task_id}">
         <MODEL-ROOT>{model_root}</MODEL-ROOT>
         <PEER-ROOT>{peer_root}</PEER-ROOT>
-        <INPUT-FORMAT TYPE="SPL">
+        <INPUT-FORMAT TYPE="SEE">
         </INPUT-FORMAT>
         <PEERS>
             {peer_elems}


### PR DESCRIPTION
Hi! I've been working with pyrouge and found out that the input format type in the configuration xml is always SPL. After a few days of work, I realized it should be SEE. 
The ROUGE package isn't well documented, but the verify.xml example file uses the SEE input type and the files referenced are formatted as the pyrouge output. The verify-spl.xml, on the other hand, uses the SPL type and references plain text files with split sentences.

As a result, the evaluation score is much higher than what should be. A similar issue is described here: http://metaoptimize.com/qa/questions/9725/rouge-evaluation-settings-for-document-summarization
(currently offline, but here is a Google caché link: http://webcache.googleusercontent.com/search?q=cache:zKvxjALPipAJ:metaoptimize.com/qa/questions/9725/rouge-evaluation-settings-for-document-summarization+&cd=1&hl=es&ct=clnk&gl=ar).

What do you think?
Regards from Argentina.